### PR TITLE
Disable type writter on mobile

### DIFF
--- a/js/type-writter-effect.js
+++ b/js/type-writter-effect.js
@@ -34,6 +34,8 @@ class TypeWriter {
       if(this.isDeleting) {
          typeSpeed /= 2;
       }
+      // Get width of device
+      var width = (window.innerWidth > 0) ? window.innerWidth : screen.width;
 
       // If word is complete
       if(!this.isDeleting && this.txt === fullTxt) {
@@ -41,6 +43,10 @@ class TypeWriter {
          typeSpeed = this.wait;
          // Set delete to true
          this.isDeleting = true;
+         // Disable on mobile screen
+         if(width < 500) {
+            return;
+         }
       } else if(this.isDeleting && this.txt === '') {
          this.isDeleting = false;
          // Move to next word
@@ -53,9 +59,11 @@ class TypeWriter {
    }
 }
 
+var width = (window.innerWidth > 0) ? window.innerWidth : screen.width;
 
-// Init On DOM Load
 document.addEventListener('DOMContentLoaded', init);
+   // document.querySelector('.txt-type').innerHTML = 'Developer';
+// Init On DOM Load
 
 // Init App
 function init() {

--- a/js/type-writter-effect.js
+++ b/js/type-writter-effect.js
@@ -62,8 +62,6 @@ class TypeWriter {
 var width = (window.innerWidth > 0) ? window.innerWidth : screen.width;
 
 document.addEventListener('DOMContentLoaded', init);
-   // document.querySelector('.txt-type').innerHTML = 'Developer';
-// Init On DOM Load
 
 // Init App
 function init() {

--- a/js/type-writter-effect.js
+++ b/js/type-writter-effect.js
@@ -35,7 +35,7 @@ class TypeWriter {
          typeSpeed /= 2;
       }
       // Get width of device
-      var width = (window.innerWidth > 0) ? window.innerWidth : screen.width;
+      const width = (window.innerWidth > 0) ? window.innerWidth : screen.width;
 
       // If word is complete
       if(!this.isDeleting && this.txt === fullTxt) {
@@ -58,8 +58,6 @@ class TypeWriter {
       setTimeout(() => this.type(), typeSpeed);
    }
 }
-
-var width = (window.innerWidth > 0) ? window.innerWidth : screen.width;
 
 document.addEventListener('DOMContentLoaded', init);
 


### PR DESCRIPTION
The **typewriter effect** on mobile screen pushes down the page, making it hard for visitors to the read `about` section. This change disables the type-writer effect on mobile screens.

**Before:**

The typewriter effect is active on mobile screens, pushing the page down, making it hard for visitors to read `about` section. 

**After:**

The typewriter effect is no longer active on mobile screens, making it easier for visitors to read `about` section. 

