### PR TITLE
Updated the calendar page with meeting notes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,9 +97,13 @@
                solid web development skills.
             </div>
             <section class="call-to-action py-5 text-sm-left" style="background: transparent">
-               <a class=" btn btn-primary js-stroll-trigger" href="https://groups.google.com/a/vt.edu/forum/?hl=en#!forum/web-development-at-vt-g" target="_blank">
-                  <span class="text-primary">Sign up</span>
-                  for our mailing list.
+               <!--<a class=" btn btn-primary js-stroll-trigger" href="https://groups.google.com/a/vt.edu/forum/?hl=en#!forum/web-development-at-vt-g" target="_blank">-->
+                  <!--<span class="text-primary">Sign up</span>-->
+                  <!--for our mailing list.-->
+               <!--</a>-->
+               <a class="btn btn-primary js-stroll-trigger" href="info.html" target="_blank">
+                  <span class="text-primary">Check out</span>
+                   our upcoming meetings.
                </a>
             </section>
          </div>
@@ -275,7 +279,7 @@
    <div class="container">
       <div class="text-center wow fadeIn">
          <h2>Instagram Feed <span style="display: none;">WebDVT</span></h2>
-         <p><a href="https://www.instagram.com/webdvt" target="_blank">Follow us</a> to learn more about what we do and stay updated on important news and events! </p>
+         <p><a href="https://www.instagram.com/webdvt" target="_blank">👉 Follow us</a> to stay updated on important news and events! </p>
          <hr class="colored">
          <br>
          <br>
@@ -314,6 +318,8 @@
             <p>
                <a href="mailto:mail@example.com">webdvt@vt.edu</a>
             </p>
+            <p class="text-center">Click <a style="color: #EF4035" target="_blank" href="https://calendar.google.com/calendar/b/1?cid=dnQuZWR1X3NwbjV1aGR1aXYyc2Rwbm11Y2w2NWJzbm1vQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">here</a> to subscribe to our calendar! </p>
+
          </div>
       </div>
       <div class="row footer-social">

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                   <!--<span class="text-primary">Sign up</span>-->
                   <!--for our mailing list.-->
                <!--</a>-->
-               <a class="btn btn-primary js-stroll-trigger" href="info.html" target="_blank">
+               <a class="btn btn-primary js-stroll-trigger" href="info.html">
                   <span class="text-primary">Check out</span>
                    our upcoming meetings.
                </a>

--- a/info.html
+++ b/info.html
@@ -93,7 +93,7 @@
 </nav>
 
 <section>
-   <div class="container fadeIn mt-5 pt-5 pb-3">
+   <div class="container fadeIn mt-5 py-5">
       <div class="row">
          <div class="col-md-10 mx-auto">
             <hr>
@@ -121,8 +121,8 @@
                   <p class="text-center">You can find all of our meeting notes here!</p>
 
                   <hr class="colored">
-                  <div class="list-group list-group-flush notes bg-light">
-                     <hr>
+                  <br>
+                  <ul class="list-group list-group-flush notes bg-light">
                      <li class="list-group-item py-5 bg-light">
                         <h4 class="mb-3">Intro to Node.js</h4>
                         <span class="text-muted"><i class="fa fa-calendar fa-fw"></i>2/23 at 2 pm</span>
@@ -139,7 +139,7 @@
                         <a target="_blank" href="https://github.com/webdvt/" class="mr-2"><i class="fa fa-github fa-fw"></i>Github Repos</a>
                         <a target="_blank" href="https://github.com/webdvt/" class="mr-2"><i class="fa fa-file fa-fw"></i>Meeting Slide</a>
                      </li>
-                  </div>
+                  </ul>
                </div>
             </div>
          </div>

--- a/info.html
+++ b/info.html
@@ -42,15 +42,11 @@
    <link href="css/vitality-red.css" rel="stylesheet" type="text/css">
    <link rel="stylesheet" href="css/style.css" type="text/css">
 
-   <!-- <link href="css/vitality-aqua.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-blue.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-green.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-orange.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-pink.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-purple.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-tan.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-turquoise.css" rel="stylesheet" type="text/css"> -->
-   <!-- <link href="css/vitality-yellow.css" rel="stylesheet" type="text/css"> -->
+   <style>
+      .notes h2, .notes h3, .notes h4, .notes h5, .notes h6 {
+         text-transform: capitalize;
+      }
+   </style>
 
 </head>
 
@@ -97,7 +93,7 @@
 </nav>
 
 <section>
-   <div class="container fadeIn mt-5 py-5">
+   <div class="container fadeIn mt-5 pt-5 pb-3">
       <div class="row">
          <div class="col-md-10 mx-auto">
             <hr>
@@ -109,10 +105,48 @@
             <div class="text-center">
                <iframe src="https://calendar.google.com/calendar/b/1/embed?showTitle=0&amp;showPrint=0&amp;showTz=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=vt.edu_spn5uhduiv2sdpnmucl65bsnmo%40group.calendar.google.com&amp;color=%23711616&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
             </div>
+            <p class="text-center">Click <a target="_blank" href="https://calendar.google.com/calendar/b/1?cid=dnQuZWR1X3NwbjV1aGR1aXYyc2Rwbm11Y2w2NWJzbm1vQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">👉 here</a> to subscribe to our calendar! </p>
             <hr>
          </div>
       </div>
    </div>
+
+
+   <section class="bg-light page-section">
+      <div class="container fadeIn   bg-light">
+         <div class="row">
+            <div class="col-md-10 mx-auto">
+               <div class=" bg-light">
+                  <h2 style="text-transform: capitalize" class="text-center">Meeting Notes</h2>
+                  <p class="text-center">You can find all of our meeting notes here!</p>
+
+                  <hr class="colored">
+                  <div class="list-group list-group-flush notes bg-light">
+                     <hr>
+                     <li class="list-group-item py-5 bg-light">
+                        <h4 class="mb-3">Intro to Node.js</h4>
+                        <span class="text-muted"><i class="fa fa-calendar fa-fw"></i>2/23 at 2 pm</span>
+                        <span class="text-muted"><i class="fa fa-map-marker fa-fw"></i>Mcbryde 113</span>
+                        <p class="my-3">Come and learn how to build a simple CRUD application with Node, Express and MongoDB! Just bring your laptop 💻 with a text editor and Node.js installed! 🍕 served!</p>
+                        <a target="_blank" href="https://github.com/webdvt/quote_app_starter" class="mr-2"><i class="fa fa-github fa-fw"></i>Github Repos</a>
+                        <a target="_blank" href="https://github.com/webdvt/quote_app_starter" class="mr-2"><i class="fa fa-file fa-fw"></i>Meeting Slide</a>
+                     </li>
+                     <li class="list-group-item py-4 bg-light">
+                        <h4 class="mb-3">Interest Meeting</h4>
+                        <span class="text-muted"><i class="fa fa-calendar fa-fw"></i>2/19 at 6 pm</span>
+                        <span class="text-muted"><i class="fa fa-map-marker fa-fw"></i>Mcbryde 129</span>
+                        <p class="my-3">Are you interested in Web Development👨‍💻👩‍💻? Come to our interest meeting this Friday and learn about what we do! 🍕 served!</p>
+                        <a target="_blank" href="https://github.com/webdvt/" class="mr-2"><i class="fa fa-github fa-fw"></i>Github Repos</a>
+                        <a target="_blank" href="https://github.com/webdvt/" class="mr-2"><i class="fa fa-file fa-fw"></i>Meeting Slide</a>
+                     </li>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+   </section>
+
+
 </section>
 
 <!-- Call to Action -->
@@ -142,6 +176,8 @@
             <p>
                <a href="mailto:mail@example.com">webdvt@vt.edu</a>
             </p>
+            <p class="text-center">Click <a style="color: #EF4035" target="_blank" href="https://calendar.google.com/calendar/b/1?cid=dnQuZWR1X3NwbjV1aGR1aXYyc2Rwbm11Y2w2NWJzbm1vQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">here</a> to subscribe to our calendar! </p>
+
          </div>
       </div>
       <div class="row footer-social">

--- a/resources.html
+++ b/resources.html
@@ -271,6 +271,8 @@
             <p>
                <a href="mailto:mail@example.com">webdvt@vt.edu</a>
             </p>
+            <p class="text-center">Click <a style="color: #EF4035" target="_blank" href="https://calendar.google.com/calendar/b/1?cid=dnQuZWR1X3NwbjV1aGR1aXYyc2Rwbm11Y2w2NWJzbm1vQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">here</a> to subscribe to our calendar! </p>
+
          </div>
       </div>
       <div class="row footer-social">

--- a/team.html
+++ b/team.html
@@ -544,6 +544,8 @@
             <p>
               <a href="mailto:mail@example.com">webdvt@vt.edu</a>
             </p>
+            <p class="text-center">Click <a style="color: #EF4035" target="_blank" href="https://calendar.google.com/calendar/b/1?cid=dnQuZWR1X3NwbjV1aGR1aXYyc2Rwbm11Y2w2NWJzbm1vQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">here</a> to subscribe to our calendar! </p>
+
           </div>
         </div>
         <div class="row footer-social">


### PR DESCRIPTION
Update the `calendar` page so we can upload the notes from each meeting directly on the page with a link to the GitHub repos. 

This way, members can always go back and see the `past meeting notes`. Ideally, this should be a table/list with a list of past and future meetings.